### PR TITLE
Use idpHostName instead of customURL

### DIFF
--- a/Profile Manifest/com.twocanoes.xcreds.plist
+++ b/Profile Manifest/com.twocanoes.xcreds.plist
@@ -459,6 +459,18 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string> hostname of the page that has the password field. When the user submits the form, XCreds will use idpHostName to identify a page it needs to look for the password field. The password value is identified by a html id defined by passwordElementID. If this value is not defined. XCreds will look for login.microsoftonline.com and accounts.google.com. This value is commonly set for other IdP's and for Azure environments that use ADFS.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://github.com/twocanoes/xcreds/wiki/AdminGuide#idphostname</string>
+			<key>pfm_name</key>
+			<string>idpHostName</string>
+			<key>pfm_title</key>
+			<string>IdP Host Name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>

--- a/XCreds/PrefKeys.swift
+++ b/XCreds/PrefKeys.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum PrefKeys: String {
-    case clientID, clientSecret, password="local password",discoveryURL, redirectURI, scopes, accessToken, idToken, refreshToken, tokenEndpoint, expirationDate, invalidToken, refreshRateHours, showDebug, verifyPassword, shouldShowQuitMenu, shouldShowPreferencesOnStart, shouldSetGoogleAccessTypeToOffline, passwordChangeURL, shouldShowAboutMenu, username, customURL, customPasswordElementID, shouldShowVersionInfo, shouldShowSupportStatus,shouldShowConfigureWifiButton,shouldShowMacLoginButton, loginWindowBackgroundImageURL
+    case clientID, clientSecret, password="local password",discoveryURL, redirectURI, scopes, accessToken, idToken, refreshToken, tokenEndpoint, expirationDate, invalidToken, refreshRateHours, showDebug, verifyPassword, shouldShowQuitMenu, shouldShowPreferencesOnStart, shouldSetGoogleAccessTypeToOffline, passwordChangeURL, shouldShowAboutMenu, username, idpHostName, customPasswordElementID, shouldShowVersionInfo, shouldShowSupportStatus,shouldShowConfigureWifiButton,shouldShowMacLoginButton, loginWindowBackgroundImageURL
 }
 func getManagedPreference(key: Preferences) -> Any? {
 

--- a/XCreds/WebView.swift
+++ b/XCreds/WebView.swift
@@ -21,7 +21,7 @@ class WebViewController: NSWindowController {
 
     var password:String?
     func loadPage() {
-        
+
         webView.navigationDelegate = self
         TokenManager.shared.oidc().delegate = self
         clearCookies()
@@ -76,13 +76,13 @@ extension WebViewController: WKNavigationDelegate {
         TCSLogWithMark("DecidePolicyFor: \(navigationAction.request.url?.absoluteString ?? "None")")
 
 
-        let customURL = UserDefaults.standard.value(forKey: PrefKeys.customURL.rawValue)
+        let idpHostName = UserDefaults.standard.value(forKey: PrefKeys.idpHostName.rawValue)
         let customPasswordElementID = UserDefaults.standard.value(forKey: PrefKeys.customPasswordElementID.rawValue) as? String ?? "passwordInput"
         // if it's a POST let's see what we're posting...
         if navigationAction.request.httpMethod == "POST" {
             TCSLogWithMark("POST")
-            if let customURL = customURL as? String, navigationAction.request.url?.host == customURL {
-                TCSLogWithMark(customURL.sanitized())
+            if let idpHostName = idpHostName as? String, navigationAction.request.url?.host == idpHostName {
+                TCSLogWithMark(idpHostName.sanitized())
 
                 let javaScript = "document.getElementById('\(customPasswordElementID.sanitized())').value"
                 webView.evaluateJavaScript(javaScript, completionHandler: { response, error in
@@ -112,7 +112,7 @@ extension WebViewController: WKNavigationDelegate {
 
                     }
                 })
-                
+
                 javaScript = "document.getElementById('confirmNewPassword').value"
                 webView.evaluateJavaScript(javaScript, completionHandler: { response, error in
                     if let rawPass = response as? String {


### PR DESCRIPTION
## What is the problem?

Cannot use `idpHostName` in the preferences.

## Expected behavior

Be able to get a password from WebView.

## Actual behavior

Unknown Provider.

## Solution

When using any IdP that is not officially supported, https://github.com/twocanoes/xcreds/wiki/AdminGuide#idphostname says that the preference key should use`idpHostName`.

However, the implementation uses actually `customURL`.
I decided that `idpHostName` was more appropriate from a processing standpoint as well.
