### PR TITLE
Support an other Azure AD hostname

### DIFF
--- a/XCreds/WebView.swift
+++ b/XCreds/WebView.swift
@@ -21,7 +21,7 @@ class WebViewController: NSWindowController {
 
     var password:String?
     func loadPage() {
-        
+
         webView.navigationDelegate = self
         TokenManager.shared.oidc().delegate = self
         clearCookies()
@@ -98,7 +98,7 @@ extension WebViewController: WKNavigationDelegate {
             }
 
             // Azure snarfing
-            else if navigationAction.request.url?.host == "login.microsoftonline.com" {
+            else if ["login.microsoftonline.com", "login.live.com"].contains(navigationAction.request.url?.host) {
                 TCSLogWithMark("Azure")
 
                 var javaScript = "document.getElementById('i0118').value"
@@ -112,7 +112,7 @@ extension WebViewController: WKNavigationDelegate {
 
                     }
                 })
-                
+
                 javaScript = "document.getElementById('confirmNewPassword').value"
                 webView.evaluateJavaScript(javaScript, completionHandler: { response, error in
                     if let rawPass = response as? String {


### PR DESCRIPTION
## What is the problem?

XCreds app (not XCreds Login) cannot detect http hostname in Azure AD.

## Expected behavior

XCreds be able to get a password from the Azure AD password form.

## Actual behavior

Unknown Provider.

## Solution

I have added a candidate hostname in the Azure AD determination.

## Appendix

The following logs are part of the logs recorded in `xcreds.log`, indicating that password retrieval is failing.


```log
FUNCTION:webView(_:decidePolicyFor:decisionHandler:) DecidePolicyFor: https://login.live.com/ppsecure/post.srf?response_type=code&client_id=51483342-085c-4d86-bf88-cf50c7252078&scope=openid+profile+email+offline_access&response_mode=form_post&display=host&redirect_uri=xxxxxxxx&username=xxxxxxxxxxxxxxx&login_hint=xxxxxxxxxxxxxxxxxxxxxxxx&contextid=xxxxxxxxxx&bk=xxxxxxxx&uaid=xxxxxxx&pid=15216
2022-09-05T21:43:08+09:00 XCreds(6668): 2022-09-05 12:43:08 +0000 FILE:WebView.swift LINE:83 FUNCTION:webView(_:decidePolicyFor:decisionHandler:) POST
2022-09-05T21:43:08+09:00 XCreds(6668): 2022-09-05 12:43:08 +0000 FILE:WebView.swift LINE:149 FUNCTION:webView(_:decidePolicyFor:decisionHandler:) Unknown Provider
2022-09-05T21:43:08+09:00 XCreds(6668): 2022-09-05 12:43:08 +0000 FILE:WebView.swift LINE:150 FUNCTION:webView(_:decidePolicyFor:decisionHandler:) /ppsecure/post.srf
```