### PR TITLE
Fixed full name to be a white space

### DIFF
--- a/XCredsLoginPlugIn/Mechanisms/XCredsCreateUser.swift
+++ b/XCredsLoginPlugIn/Mechanisms/XCredsCreateUser.swift
@@ -216,6 +216,10 @@ class XCredsCreateUser: XCredsBaseMechanism {
         
         os_log("Checking for UserProfileImage key", log: createUserLog, type: .debug)
 
+        var userFullName = [first, last].joined(separator: " ").trimmingCharacters(in: .whitespaces)
+        if userFullName.isEmpty {
+            userFullName = shortName
+        }
 
         var userPicture = getManagedPreference(key: .UserProfileImage) as? String ?? ""
         
@@ -236,7 +240,7 @@ class XCredsCreateUser: XCredsBaseMechanism {
         // let picString = picData?.description ?? ""
 
         var attrs: [AnyHashable:Any] = [
-            kODAttributeTypeFullName: [first + " " + last],
+            kODAttributeTypeFullName: [userFullName],
             kODAttributeTypeNFSHomeDirectory: [ "/Users/" + shortName ],
             kODAttributeTypeUserShell: ["/bin/bash"],
             kODAttributeTypeUniqueID: [uid],


### PR DESCRIPTION
## What is the problem?

When the provisioning of the logged-in user is completed and the user information is checked, nothing appears to be displayed.

## Expected behavior

I was expecting to see some value in the login information.

## Actual behavior

If the first and last names were not registered in the IdP, the full name would be whitespace.

##  Solution

If the first and last names were not registered in the IdP, the short name is used for the full name.
