### PR TITLE
Custom field for user account

### DIFF
--- a/XCreds/PrefKeys.swift
+++ b/XCreds/PrefKeys.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum PrefKeys: String {
-    case clientID, clientSecret, password="local password",discoveryURL, redirectURI, scopes, accessToken, idToken, refreshToken, tokenEndpoint, expirationDate, invalidToken, refreshRateHours, showDebug, verifyPassword, shouldShowQuitMenu, shouldShowPreferencesOnStart, shouldSetGoogleAccessTypeToOffline, passwordChangeURL, shouldShowAboutMenu, username, idpHostName, passwordElementID, shouldShowVersionInfo, shouldShowSupportStatus,shouldShowConfigureWifiButton,shouldShowMacLoginButton, loginWindowBackgroundImageURL
+    case clientID, clientSecret, password="local password",discoveryURL, redirectURI, scopes, accessToken, idToken, refreshToken, tokenEndpoint, expirationDate, invalidToken, refreshRateHours, showDebug, verifyPassword, shouldShowQuitMenu, shouldShowPreferencesOnStart, shouldSetGoogleAccessTypeToOffline, passwordChangeURL, shouldShowAboutMenu, username, idpHostName, passwordElementID, shouldShowVersionInfo, shouldShowSupportStatus,shouldShowConfigureWifiButton,shouldShowMacLoginButton, loginWindowBackgroundImageURL, OIDCShortName
 }
 func getManagedPreference(key: Preferences) -> Any? {
 

--- a/XCredsLoginPlugIn/LoginWindow/LoginWebViewController.swift
+++ b/XCredsLoginPlugIn/LoginWindow/LoginWebViewController.swift
@@ -107,6 +107,7 @@ class LoginWebViewController: WebViewController {
             return
         }
         var username:String
+        var oidcUsername:String = ""
         let defaultsUsername = UserDefaults.standard.string(forKey: PrefKeys.username.rawValue)
 
         let idToken = tokens.idToken
@@ -141,11 +142,28 @@ class LoginWebViewController: WebViewController {
 
         }
 
-
+        if let accountField = UserDefaults.standard.string(forKey: PrefKeys.OIDCShortName.rawValue) {
+            do {
+                TCSLogWithMark("OIDC field name for account: \(accountField)")
+                let wholeIDTokenDict = try JSONSerialization.jsonObject(with: data, options: JSONSerialization.ReadingOptions.mutableContainers) as? Dictionary<String, Any>
+                if let _ = wholeIDTokenDict?[accountField] {
+                    oidcUsername = wholeIDTokenDict?[accountField] as! String
+                } else {
+                    TCSLogWithMark("Account field set in preferences has not matching field in ID token")
+                    delegate.denyLogin()
+                    return
+                }
+            TCSLogWithMark("oidcUsername: \(oidcUsername)")
+            } catch {
+                print(error.localizedDescription)
+            }
+        }
+        
         if let defaultsUsername = defaultsUsername {
             username = defaultsUsername
-        }
-        else {
+        } else if oidcUsername != "" {
+            username = oidcUsername
+        } else {
 
 
             var emailString:String


### PR DESCRIPTION
Added amateur quality support for custom field in ID token for username. Requires preference key "OIDCShortName".

For example:
<key>OIDCShortName</key>
<string>samAccountName</string>

