### PR TITLE
Add ability to check passwords via ROPG

### DIFF
--- a/XCreds/PrefKeys.swift
+++ b/XCreds/PrefKeys.swift
@@ -12,7 +12,7 @@ enum PrefKeys: String {
          windowSignIn = "WindowSignIn", settingsOverrideScriptPath, localAdminUserName, localAdminPassword, usernamePlaceholder, passwordPlaceholder, shouldShowLocalOnlyCheckbox, shouldShowTokenUpdateStatus, shouldDetectNetworkToDetermineLoginWindow
     case ropgClientID
     case ropgClientSecret
-    case verifyPasswordWithRopg
+    case shouldVerifyPasswordWithRopg
     case actionItemOnly = "ActionItemOnly"
     case aDDomain = "ADDomain"
     case aDSite = "ADSite"

--- a/XCreds/PrefKeys.swift
+++ b/XCreds/PrefKeys.swift
@@ -10,6 +10,9 @@ import Foundation
 enum PrefKeys: String {
     case clientID, clientSecret, password="xcreds local password",discoveryURL, redirectURI, scopes, accessToken, idToken, refreshToken, tokenEndpoint, expirationDate, invalidToken, refreshRateHours,refreshRateMinutes, showDebug, verifyPassword, shouldShowQuitMenu, shouldShowPreferencesOnStart, shouldSetGoogleAccessTypeToOffline, passwordChangeURL, shouldShowAboutMenu, username, idpHostName, passwordElementID, shouldFindPasswordElement, shouldShowVersionInfo, shouldShowSupportStatus,shouldShowConfigureWifiButton,shouldShowMacLoginButton, loginWindowBackgroundImageURL, shouldShowCloudLoginByDefault, shouldPreferLocalLoginInsteadOfCloudLogin, idpHostNames,autoRefreshLoginTimer, loginWindowWidth, loginWindowHeight, shouldShowRefreshBanner, shouldSwitchToLoginWindowWhenLocked,accounts = "Accounts",
          windowSignIn = "WindowSignIn", settingsOverrideScriptPath, localAdminUserName, localAdminPassword, usernamePlaceholder, passwordPlaceholder, shouldShowLocalOnlyCheckbox, shouldShowTokenUpdateStatus, shouldDetectNetworkToDetermineLoginWindow
+    case ropgClientID
+    case ropgClientSecret
+    case verifyPasswordWithRopg
     case actionItemOnly = "ActionItemOnly"
     case aDDomain = "ADDomain"
     case aDSite = "ADSite"


### PR DESCRIPTION
### Problem statement

Okta unlike other IDPs does not revoke refresh tokens on password changes. This prevents Xcreds App from successfully detecting password changes when using Okta as an IDP, since the current method of checking password validity is via refresh tokens.

### Solution

Add capability to Xcreds to check validity of password via [Resource Owner Password  flow](https://developer.okta.com/docs/guides/implement-grant-type/ropassword/main/#about-the-resource-owner-password-grant) aka ROPG

### Implementation

For this work, an additional app will need to created in Okta as described in the ROPG flow docs. As so,
![image](https://github.com/twocanoes/xcreds/assets/5804237/fe3148c3-861b-4bc6-8f5f-5323d2a63625)

If a tenant is using OIE they might have deploy a custom sign in policy for the app that only enforces a single factor for authentication. This is a departure from how the classic engine works whereby it defaults to single factor challenge for ROPG flows.

There additional preferences keys have been added to make this possible
```
                       <key>verifyPasswordWithRopg</key>
                       <true/>
                      	<key>ropgClientID</key>
			<string>appclientID</string>
                      	<key>ropgClientSecret</key>
			<string>oktaAppSecret</string>
```

If any of the key above are missing Xcreds will default to using refresh token flow for password verification.

Sample log of changes in action, first verification was with an invalid profile.
https://gist.github.com/hurricanehrndz/6a63bc5caa6890dc530d324a8724ed97
