### PR TITLE
Reload login window on network changes

### DIFF
--- a/XCreds/AppDelegate.swift
+++ b/XCreds/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var loginPasswordWindow: NSWindow!
     @IBOutlet var window: NSWindow!
     var mainController:MainController?
-    var wifiWindowController:WifiWindowController?
     var screenIsLocked=true
     var isDisplayAsleep=true
     var waitForScreenToWake=false

--- a/XCredsLoginPlugIn/LoginWindow/LoginWebViewWindowController.swift
+++ b/XCredsLoginPlugIn/LoginWindow/LoginWebViewWindowController.swift
@@ -42,7 +42,6 @@ class LoginWebViewWindowController: WebViewWindowController {
         for currentBundle in allBundles {
             TCSLogWithMark(currentBundle.bundlePath)
             if currentBundle.bundlePath.contains("XCreds") {
-
                 controlsViewController = ControlsViewController.init(nibName: NSNib.Name("ControlsViewController"), bundle: currentBundle)
                 if let controlsViewController = controlsViewController {
                     self.window?.contentView?.addSubview(controlsViewController.view)
@@ -54,33 +53,17 @@ class LoginWebViewWindowController: WebViewWindowController {
                 else {
                     TCSLogWithMark("controlsViewController nil")
                 }
-
             }
         }
-        TCSLogWithMark()
-        networkChangeObserver = NotificationCenter.default.addObserver(forName:NSNotification.Name("NetworkChanged"), object: nil, queue: nil) { notification in
-            //            TCSLogWithMark("network changed.")
-            let userInfo = notification.userInfo as? [String:Bool]
-            if let userInfo = userInfo, let networkStatus = userInfo["online"], networkStatus==true {
-                self.loadPage()
-            }
-        }
-
-
 
         resolutionObserver = NotificationCenter.default.addObserver(forName:NSApplication.didChangeScreenParametersNotification, object: nil, queue: nil) { notification in
             TCSLogWithMark("Resolution changed. Resetting size")
-
             self.setupLoginWindowAppearance()
-
         }
+
         TCSLogWithMark("loading webview for login")
         setupLoginWindowAppearance()
-
         TCSLogWithMark("loading page")
-
-        
-
         loadPage()
     }
 

--- a/XCredsLoginPlugIn/LoginWindow/NetworkMonitor.swift
+++ b/XCredsLoginPlugIn/LoginWindow/NetworkMonitor.swift
@@ -1,0 +1,72 @@
+//
+//  NetworkMonitor.swift
+//  XCredsLoginPlugin
+//
+//  Created by Carlos Hernandez on 2023-10-22.
+//
+
+import Foundation
+import Network
+
+extension Notification.Name {
+    static let connectivityStatus = Notification.Name(rawValue: "connectivityStatusChanged")
+}
+
+extension NWInterface.InterfaceType: CaseIterable {
+    public static var allCases: [NWInterface.InterfaceType] = [
+        .other,
+        .wifi,
+        .cellular,
+        .loopback,
+        .wiredEthernet
+    ]
+}
+
+final class NetworkMonitor {
+    static let shared = NetworkMonitor()
+
+    private let queue = DispatchQueue(label: "NetworkConnectivityMonitor")
+    private let monitor: NWPathMonitor
+
+    private(set) var isConnected = false
+    private(set) var isExpensive = false
+    private(set) var lastNotification: Date?
+    private(set) var currentConnectionType: NWInterface.InterfaceType?
+
+    private init() {
+        monitor = NWPathMonitor(prohibitedInterfaceTypes: [.cellular, .loopback])
+    }
+
+    func startMonitoring() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            TCSLogWithMark("Network monitor: path updated")
+            self?.isConnected = path.status == .satisfied
+            self?.isExpensive = path.isExpensive
+            self?.currentConnectionType = NWInterface.InterfaceType.allCases.filter { path.usesInterfaceType($0) }.first
+            if WifiManager().isConnectedToNetwork() == true {
+                TCSLogWithMark("Network monitor: connected to network")
+                if let lastNotification = self?.lastNotification {
+                    if abs(lastNotification.timeIntervalSinceNow) > 5 {
+                        TCSLogWithMark("Network monitor: posting connectivity status to NC: \(path.status) for \(String(describing: self?.currentConnectionType))")
+                        self?.lastNotification = Date()
+                        NotificationCenter.default.post(name: .connectivityStatus, object: nil)
+                    } else {
+                        TCSLogWithMark("Network monitor: debouncing connectivity status to NC")
+                    }
+                } else {
+                    TCSLogWithMark("Network monitor: posting connectivity status to NC: \(path.status) for \(String(describing: self?.currentConnectionType))")
+                    self?.lastNotification = Date()
+                    NotificationCenter.default.post(name: .connectivityStatus, object: nil)
+                }
+            } else {
+                TCSLogWithMark("Not connected to network, no notfication posted")
+            }
+        }
+        monitor.start(queue: queue)
+    }
+
+    func stopMonitoring() {
+        TCSLogWithMark("Network monitor: stopping")
+        monitor.cancel()
+    }
+}

--- a/xCreds.xcodeproj/project.pbxproj
+++ b/xCreds.xcodeproj/project.pbxproj
@@ -7,7 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		081904872AFAE61800F7DA33 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081904862AFAE61800F7DA33 /* NetworkMonitor.swift */; };
+		089B22F12AFAED280006B6BC /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B22F02AFAED280006B6BC /* NetworkMonitor.swift */; };
+		089B22F22AFAED810006B6BC /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 089B22F02AFAED280006B6BC /* NetworkMonitor.swift */; };
 		760418D12A1332210051411B /* SignIn.xib in Resources */ = {isa = PBXBuildFile; fileRef = 760418CE2A1332210051411B /* SignIn.xib */; };
 		760418D22A1332210051411B /* SignInWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 760418CF2A1332210051411B /* SignInWindowController.swift */; };
 		760418D52A1332520051411B /* DS+AD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 760418D42A1332520051411B /* DS+AD.swift */; };
@@ -280,7 +281,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		081904862AFAE61800F7DA33 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkMonitor.swift; path = XCredsLoginPlugIn/LoginWindow/NetworkMonitor.swift; sourceTree = "<group>"; };
+		089B22F02AFAED280006B6BC /* NetworkMonitor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkMonitor.swift; path = XCredsLoginPlugIn/LoginWindow/NetworkMonitor.swift; sourceTree = SOURCE_ROOT; };
 		760418CE2A1332210051411B /* SignIn.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SignIn.xib; sourceTree = "<group>"; };
 		760418CF2A1332210051411B /* SignInWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInWindowController.swift; sourceTree = "<group>"; };
 		760418D42A1332520051411B /* DS+AD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DS+AD.swift"; sourceTree = "<group>"; };
@@ -575,6 +576,7 @@
 			isa = PBXGroup;
 			children = (
 				761B486828A34CC900C6A02B /* LoginProgressWindowController.swift */,
+				089B22F02AFAED280006B6BC /* NetworkMonitor.swift */,
 				761B486728A34CC900C6A02B /* LoginProgressWindowController.xib */,
 				76CB907C288112AF00C70D0C /* xcreds_login.sh */,
 				76BEF7F928726C700013E2A1 /* AuthorizationDBManager.swift */,
@@ -640,7 +642,6 @@
 		76EE069127FD1D00009E0F3A = {
 			isa = PBXGroup;
 			children = (
-				081904862AFAE61800F7DA33 /* NetworkMonitor.swift */,
 				7681FEC82A4CFEA200F91CD1 /* com.twocanoes.xcreds.plist */,
 				76C63A312A22872700810C53 /* History.md */,
 				760418CC2A1331710051411B /* NomadLogin */,
@@ -1019,7 +1020,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				081904872AFAE61800F7DA33 /* NetworkMonitor.swift in Sources */,
 				7632E3A32873581100E37923 /* KeychainUtil.swift in Sources */,
 				76B882AB29CCFD7A00BB8186 /* TCSKeychain.m in Sources */,
 				76BEF7DD2871F5F00013E2A1 /* TCSReturnWindow.m in Sources */,
@@ -1068,6 +1068,7 @@
 				76BEF7F628724FA80013E2A1 /* NSTaskWrapper.swift in Sources */,
 				76EECD0528753C7F00483C66 /* String+Base64URLEncoded.swift in Sources */,
 				766355DB287132E9002E3867 /* LoginWebViewWindowController.swift in Sources */,
+				089B22F12AFAED280006B6BC /* NetworkMonitor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1112,6 +1113,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				089B22F22AFAED810006B6BC /* NetworkMonitor.swift in Sources */,
 				76EECD0228752C1F00483C66 /* LoginWindow.swift in Sources */,
 				76673CD529D3D5F500452848 /* LicenseChecker.swift in Sources */,
 				767116A7284AABC500CCD6FF /* NotifyManager.swift in Sources */,

--- a/xCreds.xcodeproj/project.pbxproj
+++ b/xCreds.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		081904872AFAE61800F7DA33 /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081904862AFAE61800F7DA33 /* NetworkMonitor.swift */; };
 		760418D12A1332210051411B /* SignIn.xib in Resources */ = {isa = PBXBuildFile; fileRef = 760418CE2A1332210051411B /* SignIn.xib */; };
 		760418D22A1332210051411B /* SignInWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 760418CF2A1332210051411B /* SignInWindowController.swift */; };
 		760418D52A1332520051411B /* DS+AD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 760418D42A1332520051411B /* DS+AD.swift */; };
@@ -279,6 +280,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		081904862AFAE61800F7DA33 /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NetworkMonitor.swift; path = XCredsLoginPlugIn/LoginWindow/NetworkMonitor.swift; sourceTree = "<group>"; };
 		760418CE2A1332210051411B /* SignIn.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SignIn.xib; sourceTree = "<group>"; };
 		760418CF2A1332210051411B /* SignInWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInWindowController.swift; sourceTree = "<group>"; };
 		760418D42A1332520051411B /* DS+AD.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DS+AD.swift"; sourceTree = "<group>"; };
@@ -638,6 +640,7 @@
 		76EE069127FD1D00009E0F3A = {
 			isa = PBXGroup;
 			children = (
+				081904862AFAE61800F7DA33 /* NetworkMonitor.swift */,
 				7681FEC82A4CFEA200F91CD1 /* com.twocanoes.xcreds.plist */,
 				76C63A312A22872700810C53 /* History.md */,
 				760418CC2A1331710051411B /* NomadLogin */,
@@ -902,7 +905,7 @@
 					};
 				};
 			};
-			buildConfigurationList = 76EE069527FD1D00009E0F3A /* Build configuration list for PBXProject "XCreds" */;
+			buildConfigurationList = 76EE069527FD1D00009E0F3A /* Build configuration list for PBXProject "xCreds" */;
 			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -1016,6 +1019,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				081904872AFAE61800F7DA33 /* NetworkMonitor.swift in Sources */,
 				7632E3A32873581100E37923 /* KeychainUtil.swift in Sources */,
 				76B882AB29CCFD7A00BB8186 /* TCSKeychain.m in Sources */,
 				76BEF7DD2871F5F00013E2A1 /* TCSReturnWindow.m in Sources */,
@@ -1699,7 +1703,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		76EE069527FD1D00009E0F3A /* Build configuration list for PBXProject "XCreds" */ = {
+		76EE069527FD1D00009E0F3A /* Build configuration list for PBXProject "xCreds" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				76EE06A527FD1D01009E0F3A /* Debug */,


### PR DESCRIPTION
## Notes
Upon testing, we noticed `allowLogin` and `denyLogin` were being called while sitting at the Webview Login Window, thus preemptively killing the network monitor.
We moved the logic around so that the monitoring starts and stops based on which Login Window is loaded.
Would love some feedback if there is a smoother way to achieve this.
So far these changes have given us the desired behavior when onboarding new users.

Credit to @hurricanehrndz and the CPE Team at Yelp.