### PR TITLE
Allow forciblly to enable Web Auth for ROPG auth

### DIFF
--- a/XCreds/MainController.swift
+++ b/XCreds/MainController.swift
@@ -56,7 +56,7 @@ class MainController: NSObject, UpdateCredentialsFeedbackProtocol {
         NSApp.activate(ignoringOtherApps: true)
 
         scheduleManager.setNextCheckTime()
-        if DefaultsOverride.standardOverride.value(forKey: PrefKeys.shouldVerifyPasswordWithRopg.rawValue) != nil || DefaultsOverride.standardOverride.value(forKey: PrefKeys.aDDomain.rawValue) != nil
+        if (DefaultsOverride.standardOverride.value(forKey: PrefKeys.shouldVerifyPasswordWithRopg.rawValue) != nil || DefaultsOverride.standardOverride.value(forKey: PrefKeys.aDDomain.rawValue) != nil) && DefaultsOverride.standardOverride.value(forKey: PrefKeys.shouldUpdatePasswordWithWebview.rawValue) == nil
         {
 
             if let window = windowController.window{

--- a/XCreds/PrefKeys.swift
+++ b/XCreds/PrefKeys.swift
@@ -10,6 +10,8 @@ import Foundation
 enum PrefKeys: String {
     case clientID, clientSecret, password="xcreds local password",discoveryURL, redirectURI, scopes, accessToken, idToken, refreshToken, tokenEndpoint, expirationDate, invalidToken, refreshRateHours,refreshRateMinutes, showDebug, verifyPassword, shouldShowQuitMenu, shouldShowPreferencesOnStart, shouldSetGoogleAccessTypeToOffline, passwordChangeURL, shouldShowAboutMenu, username, idpHostName, passwordElementID, shouldFindPasswordElement, shouldShowVersionInfo, shouldShowSupportStatus,shouldShowConfigureWifiButton,shouldShowMacLoginButton, loginWindowBackgroundImageURL, shouldShowCloudLoginByDefault, shouldPreferLocalLoginInsteadOfCloudLogin, idpHostNames,autoRefreshLoginTimer, loginWindowWidth, loginWindowHeight, shouldShowRefreshBanner, shouldSwitchToLoginWindowWhenLocked,accounts = "Accounts",
          windowSignIn = "WindowSignIn", settingsOverrideScriptPath, localAdminUserName, localAdminPassword, usernamePlaceholder, passwordPlaceholder, shouldShowLocalOnlyCheckbox, shouldShowTokenUpdateStatus, shouldDetectNetworkToDetermineLoginWindow, showLoginWindowDelaySeconds, shouldPromptForMigration, shouldAllowKeyComboForMacLoginWindow, aliasName,claimsToAddToLocalUserAccount, loadPageTitle, loadPageInfo,shouldPromptForADPasswordChange, hideIfPathExists, allowedUsersArray, allowUsersClaim
+    case ropgClientID
+    case ropgClientSecret
     case shouldVerifyPasswordWithRopg
     case shouldUpdatePasswordWithWebview
     case shouldUseROPGForOIDCLogin

--- a/XCreds/PrefKeys.swift
+++ b/XCreds/PrefKeys.swift
@@ -11,6 +11,7 @@ enum PrefKeys: String {
     case clientID, clientSecret, password="xcreds local password",discoveryURL, redirectURI, scopes, accessToken, idToken, refreshToken, tokenEndpoint, expirationDate, invalidToken, refreshRateHours,refreshRateMinutes, showDebug, verifyPassword, shouldShowQuitMenu, shouldShowPreferencesOnStart, shouldSetGoogleAccessTypeToOffline, passwordChangeURL, shouldShowAboutMenu, username, idpHostName, passwordElementID, shouldFindPasswordElement, shouldShowVersionInfo, shouldShowSupportStatus,shouldShowConfigureWifiButton,shouldShowMacLoginButton, loginWindowBackgroundImageURL, shouldShowCloudLoginByDefault, shouldPreferLocalLoginInsteadOfCloudLogin, idpHostNames,autoRefreshLoginTimer, loginWindowWidth, loginWindowHeight, shouldShowRefreshBanner, shouldSwitchToLoginWindowWhenLocked,accounts = "Accounts",
          windowSignIn = "WindowSignIn", settingsOverrideScriptPath, localAdminUserName, localAdminPassword, usernamePlaceholder, passwordPlaceholder, shouldShowLocalOnlyCheckbox, shouldShowTokenUpdateStatus, shouldDetectNetworkToDetermineLoginWindow, showLoginWindowDelaySeconds, shouldPromptForMigration, shouldAllowKeyComboForMacLoginWindow, aliasName,claimsToAddToLocalUserAccount, loadPageTitle, loadPageInfo,shouldPromptForADPasswordChange, hideIfPathExists, allowedUsersArray, allowUsersClaim
     case shouldVerifyPasswordWithRopg
+    case shouldUpdatePasswordWithWebview
     case shouldUseROPGForOIDCLogin
     case actionItemOnly = "ActionItemOnly"
     case aDDomain = "ADDomain"

--- a/XCreds/TokenManager.swift
+++ b/XCreds/TokenManager.swift
@@ -52,26 +52,38 @@ class TokenManager: OIDCLiteDelegate,DSQueryable {
         var scopes: [String]?
         var additionalParameters:[String:String]? = nil
         var clientSecret:String?
+        var clientID:String?
 
         if let oidcPrivate = oidcLocal {
             oidcPrivate.getEndpoints()
 
             return oidcPrivate
         }
-        if let clientSecretRaw = DefaultsOverride.standardOverride.string(forKey: PrefKeys.clientSecret.rawValue),
+        let clientSecretRaw = DefaultsOverride.standardOverride.string(forKey: PrefKeys.ropgClientSecret.rawValue) != nil ? DefaultsOverride.standardOverride.string(forKey: PrefKeys.ropgClientSecret.rawValue) : DefaultsOverride.standardOverride.string(forKey: PrefKeys.clientSecret.rawValue)
+            
+        if let clientSecretRaw = clientSecretRaw,
            clientSecretRaw != "" {
             clientSecret = clientSecretRaw
         }
+        
+        let clientIDRaw = DefaultsOverride.standardOverride.string(forKey: PrefKeys.ropgClientID.rawValue) != nil ? DefaultsOverride.standardOverride.string(forKey: PrefKeys.ropgClientID.rawValue) : DefaultsOverride.standardOverride.string(forKey: PrefKeys.clientID.rawValue)
+        
+        if let clientIDRaw = clientIDRaw,
+           clientSecretRaw != "" {
+            clientID = clientIDRaw
+        }
+        
         if let scopesRaw = DefaultsOverride.standardOverride.string(forKey: PrefKeys.scopes.rawValue) {
             scopes = scopesRaw.components(separatedBy: " ")
         }
+
         //
         if DefaultsOverride.standardOverride.bool(forKey: PrefKeys.shouldSetGoogleAccessTypeToOffline.rawValue) == true {
 
             additionalParameters = ["access_type":"offline"]
         }
 
-        let oidcLite = OIDCLite(discoveryURL: DefaultsOverride.standardOverride.string(forKey: PrefKeys.discoveryURL.rawValue) ?? "NONE", clientID: DefaultsOverride.standardOverride.string(forKey: PrefKeys.clientID.rawValue) ?? "NONE", clientSecret: clientSecret, redirectURI: DefaultsOverride.standardOverride.string(forKey: PrefKeys.redirectURI.rawValue), scopes: scopes, additionalParameters:additionalParameters )
+        let oidcLite = OIDCLite(discoveryURL: DefaultsOverride.standardOverride.string(forKey: PrefKeys.discoveryURL.rawValue) ?? "NONE", clientID: clientID ?? "NONE", clientSecret: clientSecret ?? "NONE", redirectURI: DefaultsOverride.standardOverride.string(forKey: PrefKeys.redirectURI.rawValue), scopes: scopes, additionalParameters:additionalParameters )
         oidcLite.getEndpoints()
         oidcLocal = oidcLite
         oidcLite.delegate=self


### PR DESCRIPTION
This will empower user to forcibly enable Webview for Auth with ROPG for password verification. Password verification will still happen silently when the keychain has the right password.

This mode is a mix and match of two modes, Native ROPG Authenticaion and Webview Authentication.

For this to work the following we be required

## Okta
2 Applications:
- OIDC Native app with Resource owner password grant enable and MFA disabled
- OIDC Web Application

## Config
For preferences the following must be defined
- ropgClientID
- ropgClientSeceret
- shouldUpdatePasswordWithWebview
- shouldVerifyPasswordWithRopg

Why would you want this? If you are shipping new devices to new users who have yet to setup an MFA challenge, it is only possible to complete via a webview