### PR TITLE
Minor fixes for ropg

### DIFF
--- a/XCredsLoginPlugIn/Mechanisms/XCredsCreateUser.swift
+++ b/XCredsLoginPlugIn/Mechanisms/XCredsCreateUser.swift
@@ -311,7 +311,9 @@ class XCredsCreateUser: XCredsBaseMechanism, DSQueryable {
         if let alias = alias {
             TCSLogWithMark("saving alias to DS as a username for ropg as needed")
             try? records.first?.setValue(alias, forAttribute: "dsAttrTypeNative:_xcreds_oidc_username")
-
+        } else {
+            TCSLogWithMark("Fallback,saving account name to DS as username for ropg as needed")
+            try? records.first?.setValue(user, forAttribute: "dsAttrTypeNative:_xcreds_oidc_username")
         }
 
 

--- a/XCredsLoginPlugIn/Mechanisms/XCredsLoginMechanism.swift
+++ b/XCredsLoginPlugIn/Mechanisms/XCredsLoginMechanism.swift
@@ -166,7 +166,8 @@ import Network
         let preferLocalLogin = DefaultsOverride.standardOverride.bool(forKey: PrefKeys.shouldPreferLocalLoginInsteadOfCloudLogin.rawValue)
         let shouldDetectNetwork = DefaultsOverride.standardOverride.bool(forKey: PrefKeys.shouldDetectNetworkToDetermineLoginWindow.rawValue)
 
-        let useROPG = DefaultsOverride.standardOverride.bool(forKey: PrefKeys.shouldUseROPGForLoginWindow.rawValue)
+        let useROPG = DefaultsOverride.standardOverride.bool(forKey: PrefKeys.shouldUseROPGForLoginWindowLogin
+.rawValue)
 
 
         TCSLogWithMark("checking if local login")


### PR DESCRIPTION
Use macos account name as a fallback for DS attribute when alias is not specified.

Fix preference for shouldUseROPGForLoginWindowLogin.