### PR TITLE
Refresh override script cache before password overwrite in XCredsCreateUser

### DIFF
--- a/XCredsLoginPlugIn/Mechanisms/XCredsCreateUser.swift
+++ b/XCredsLoginPlugIn/Mechanisms/XCredsCreateUser.swift
@@ -215,8 +215,8 @@ class XCredsCreateUser: XCredsBaseMechanism {
                 TCSLogWithMark("Password Overwrite enabled and triggered, starting evaluation")
                 
                 TCSLogWithMark("trying to getting admin user and password")
-
-                if let localAdmin = getHint(type: .localAdmin) as? LocalAdminCredentials {
+                DefaultsOverride.standardOverride.refreshCachedPrefs()
+                if let localAdmin = PasswordUtils().localAdminCredentialsFromPrefs() ?? getHint(type: .localAdmin) as? LocalAdminCredentials {
                     TCSLogWithMark("resetting password with admin username and password")
 
                    let res=resetUserPassword(adminUserName: localAdmin.username, adminPassword: localAdmin.password)


### PR DESCRIPTION
Updating this PR. After more testing, I realized the first version of the fix doesn't help if LAPS rotates while at the XCreds login window, and then a user goes to login with a changed IdP password.

Moved refreshCachedPrefs() to XCredsCreateUser, right before a password overwrite is needed. It only runs during PasswordOverwriteSilent when a password mismatch is detected, so normal logins are unaffected. Existing set-admin-user workflows are also unaffected.

Tested by rotating LAPS while at the login window, then logging in with a changed cloud password. Password overwrite succeeded with the post-rotation creds:

```
2026-04-29 11:13:54.000 Df authorizationhosthelper.arm64[7536:4d834d] (XCredsLoginPlugin) XCREDS_LOG:      DefaultsOverride.swift:32 refreshCachedPrefs() Pref script defined at /usr/local/bin/xcreds_override.sh
2026-04-29 11:13:54.459 A  authorizationhosthelper.arm64[7536:4d834d] (CFOpenDirectory) Change the credential used to operate on a record
2026-04-29 11:13:54.646 A  authorizationhosthelper.arm64[7536:4d834d] (CFOpenDirectory) Change password for record
```

Without this fix, the same test fails with stale cached credentials.