### PR TITLE
Fix settingsOverrideScriptPath crash when path contains a space

### DIFF
--- a/DefaultsOverride.swift
+++ b/DefaultsOverride.swift
@@ -66,7 +66,18 @@ public class DefaultsOverride: UserDefaults {
 
             }
             
-            let scriptRes=cliTask(prefScriptPath)
+            // Pass an explicit (empty) arguments array so cliTask takes its
+            // no-split branch. The single-string overload splits `command` by
+            // " " to derive launchPath, which breaks any path containing a
+            // space — including the Apple-conventional installer location
+            // /Library/Application Support/<vendor>/<helper>. With the bare
+            // call, NSConcreteTask throws "launch path not accessible" and
+            // takes down the SecurityAgent auth chain on every loginwindow
+            // cycle. cliTask already handles arguments != nil by using the
+            // command verbatim as launchPath, which is what we want here:
+            // settingsOverrideScriptPath is documented as the *path* to the
+            // helper, not a shell command line.
+            let scriptRes=cliTask(prefScriptPath, arguments: [])
 
                 if scriptRes.count==0{
                     TCSLogErrorWithMark("script did not return anything")


### PR DESCRIPTION
## Summary
Found this bug when trying to locate my `settingsOverrideScriptPath` in `/Library/Application Support`.

`DefaultsOverride.swift:69` calls `cliTask(prefScriptPath)`. The single-string overload splits `command` on `" "` to derive `launchPath` (`UNIXUtilities.swift:29`), corrupting any `settingsOverrideScriptPath` that contains a space. `NSConcreteTask` then throws `launch path not accessible`, crashing the plugin during `refreshCachedPrefs()` and stalling the auth chain.

The backslash-rebuild branch in `cliTask` can't rescue this caller — `refreshCachedPrefs` pre-validates with `FileManager.fileExists(atPath:)` on the raw string, so an escaped path fails fileExists and an unescaped path crashes cliTask.

## Fix

```diff
-            let scriptRes=cliTask(prefScriptPath)
+            let scriptRes=cliTask(prefScriptPath, arguments: [])
```

Takes the existing `arguments != nil` branch in `cliTask`, which uses `command` verbatim as `launchPath`.