### PR TITLE
get_pw.js: descend into shadow roots when collecting password fields

### DIFF
--- a/Javascript/get_pw/get_pw.js
+++ b/Javascript/get_pw/get_pw.js
@@ -4,9 +4,24 @@ var result = {
   "ids": [],
 };
 
+// Collect password fields, descending into shadow roots.
+//
+// document.querySelectorAll() does not traverse shadow DOM, so IdPs that render
+// their login form with web components hide the password field from the query.
+// authentik is one such IdP: the field is <input id="ak-stage-password-input">
+// inside the shadow root of <ak-stage-password>, and capture silently returns
+// nothing, so the local account password can never be set.
+function collectPasswordFields(root) {
+  root.querySelectorAll('[type="password"]').forEach(i => elements.add(i));
+  root.querySelectorAll('*').forEach(function (e) {
+    if (e.shadowRoot) {
+      collectPasswordFields(e.shadowRoot);
+    }
+  });
+}
+
 function watchWindow(){
-  var passwordElements = document.querySelectorAll('[type="password"]');
-  passwordElements.forEach(i=>elements.add(i));
+  collectPasswordFields(document);
   var elementsArray = Array.from(elements);
 
   if (elementsArray.length == 0) {


### PR DESCRIPTION
Fixes #398.

`document.querySelectorAll()` does not traverse shadow DOM, so IdPs that render
their login form with web components hide the password field from the query in
`get_pw.js`. Capture silently returns nothing and the local account password is
never set — login ends at *"Password not set. Verify username mapping in
configuration is correct and you are not using passwordless login."*

authentik is one such IdP, and is a [documented XCreds integration](https://integrations.goauthentik.io/security/xcreds/),
so this affects a published path. Its field is `<input id="ak-stage-password-input">`
inside the shadow root of `<ak-stage-password>`.

### Change

`collectPasswordFields()` runs the existing `[type="password"]` query at each
root and recurses into any `shadowRoot` it finds.

### Measured on the authentik password stage

```
document.querySelectorAll('[type="password"]')  ->  0 elements
recursive shadowRoot walk                       ->  1 element, value readable
```

### Compatibility

- Light-DOM forms are unaffected — the same query still runs at the document root.
- `input` events are composed and cross shadow boundaries, so the existing
  `window.addEventListener('input', watchWindow)` continues to work unchanged.
- Extends the light-DOM handling added via #358, which addressed a field whose
  *type* changes; this addresses a field the selector cannot *reach*.

### Note for reviewers reproducing this

On authentik's **identification** stage (before a username is entered) there are
hidden light-DOM helper inputs for password managers:

```
name="password"  id=""  inShadow: false  visible: false
```

`document.querySelectorAll('[type="password"]')` returns 1 there, and writing to
it and reading it back appears to work — a false positive. The real field only
appears on the password stage. It may also be worth filtering to visible fields
(`offsetParent !== null`) so these helpers are never picked up.

I was unable to build and run the full app to test end to end, as `Cartfile` and
`.gitmodules` reference private Bitbucket repositories. The JavaScript change was
verified directly against a live authentik login page.
